### PR TITLE
Cuts the user's FPS in half

### DIFF
--- a/Scripts/15FPS.js
+++ b/Scripts/15FPS.js
@@ -1,0 +1,23 @@
+// Created by Nicholas Dominici
+// Last updated on 11/17/2019
+// Contact me at imnick43@gmail.com
+
+// INSTRUCTIONS: SETUP ANOTHER RENDER TARGET AND ANOTHER CAMERA ON THAT RENDER TARGET ON A NEW LAYER AND APPLY THAT RENDER TARGET TO A SCREEN IMAGE.
+
+//@input Component.Camera cam
+
+
+var frameindex = 0
+
+var event = script.createEvent("UpdateEvent");
+event.bind(function (eventData){
+
+    frameindex++
+
+    //Applies textureCopy to the sprite
+    if (frameindex%2 == 0){
+        script.cam.enabled = false;
+    }else{
+        script.cam.enabled = true;
+    }
+});


### PR DESCRIPTION
A script to halve the FPS of the user's camera by enabling and disabling the camera.  This method doesn't store any frames, meaning it won't crash.